### PR TITLE
Use 'bytes' instead of 'octets' in download progress indicator

### DIFF
--- a/portablemc/cli/__init__.py
+++ b/portablemc/cli/__init__.py
@@ -763,8 +763,8 @@ class StartWatcher(SimpleWatcher):
         self.ns.out.task("..", "download.progress", 
             count=count,
             total_count=total_count,
-            size=f"{format_number(self.size + sum(self.sizes))}o",
-            speed=f"{format_number(speed)}o/s")
+            size=f"{format_number(self.size + sum(self.sizes))}B",
+            speed=f"{format_number(speed)}B/s")
 
         if e.done:
             self.size += e.size


### PR DESCRIPTION
Update the lesser-known variant `Mo/s` (megaoctets per second) to the more globally familiar `MB/s` (megabytes per second).